### PR TITLE
Automated repair through risk intelligence platform in 2023-04-25 11:37:56

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 			 <dependency>
 			    <groupId>org.apache.logging.log4j</groupId>
 			    <artifactId>log4j-core</artifactId>
-			    <version>2.8.2</version>
+			    <version>2.16.0</version>
 			</dependency>
 		
         </dependencies>


### PR DESCRIPTION
修改组件依赖:   
pom.xml中修改dependency将org.apache.logging.log4j:log4j-core的版本由2.8.2修改为2.16.0.   
.   
本功能是自动修复漏洞功能，需要人工确认修复是否正确。