### PR TITLE
Automated repair through risk intelligence platform in 2023-04-27 15:00:55

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 			<dependency>
 				<groupId>com.alibaba</groupId>
 				<artifactId>fastjson</artifactId>
-				<version>1.2.68</version>
+				<version>2.8.3</version>
 			</dependency>	
          </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
修改组件依赖:   
pom.xml中修改dependency将com.alibaba:fastjson的版本由1.2.68修改为2.8.3.   
.   
本功能是自动修复漏洞功能，需要人工确认修复是否正确。