### PR TITLE
Automated repair through risk intelligence platform in 2023-05-24 10:14:35

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,8 +228,8 @@
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-shared-utils</artifactId>
-            <version>3.2.1</version>
-            <type>pom</type>
+            <version>3.3.3</version>
+            <type>jar</type>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
修改组件依赖:   
pom.xml中修改dependency将org.apache.maven.shared:maven-shared-utils的版本由3.2.1修改为3.3.3.   

本功能是自动修复漏洞功能，需要人工确认修复是否正确。