### PR TITLE
Automated repair through risk intelligence platform in 2023-05-26 15:20:42

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,16 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
+            <groupId>com.alipay.dmeta</groupId>
+            <artifactId>dmeta-common-holo-rewrite</artifactId>
+            <version>1.0.0.20191014</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>jraft-parent</artifactId>
+            <version>1.3.4</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-client</artifactId>
             <version>5.7.0</version>
@@ -85,7 +95,7 @@
         <dependency>
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
-            <version>2.3.0.RELEASE</version>
+            <version>2.3.3.RELEASE</version>
         </dependency>
 
         <dependency>
@@ -109,19 +119,19 @@
         <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-spring</artifactId>
-            <version>1.8.0</version>
+            <version>1.9.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-saml2-service-provider</artifactId>
-            <version>5.2.0.RELEASE</version>
+            <version>5.2.4.RELEASE</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.webflow</groupId>
             <artifactId>spring-webflow</artifactId>
-            <version>2.4.0.RELEASE</version>
+            <version>2.4.5</version>
         </dependency>
 
         <dependency>
@@ -151,7 +161,7 @@
         <dependency>
             <groupId>org.apache.syncope</groupId>
             <artifactId>syncope-archetype</artifactId>
-            <version>2.1.0</version>
+            <version>2.1.7</version>
         </dependency>
 
         <dependency>
@@ -171,8 +181,8 @@
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-shared-utils</artifactId>
-            <version>3.2.1</version>
-            <type>pom</type>
+            <version>3.3.3</version>
+            <type>jar</type>
         </dependency>
 
         <dependency>
@@ -184,13 +194,13 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>3.0.6</version>
+            <version>3.0.16</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.geode</groupId>
             <artifactId>geode-core</artifactId>
-            <version>1.14.4</version>
+            <version>1.15.0</version>
         </dependency>
 
       


### PR DESCRIPTION
修改组件依赖:   
pom.xml中修改dependency将org.apache.maven.shared:maven-shared-utils的版本由3.2.1修改为3.3.3.   
修改组件依赖:   
pom.xml中修改dependency将org.springframework.security.oauth:spring-security-oauth2的版本由2.3.0.RELEASE修改为2.3.3.RELEASE.   
修改组件依赖:   
pom.xml中修改dependency将org.springframework.webflow:spring-webflow的版本由2.4.0.RELEASE修改为2.4.5.   
修改组件依赖:   
pom.xml中修改dependency将org.apache.syncope:syncope-archetype的版本由2.1.0修改为2.1.7.   
修改组件依赖:   
pom.xml中修改dependency将org.apache.geode:geode-core的版本由1.14.4修改为1.15.0.   
修改组件依赖:   
pom.xml中修改dependency将org.codehaus.plexus:plexus-utils的版本由3.0.6修改为3.0.16.   
修改组件依赖:   
pom.xml中新增dependency:com.alipay.sofa:jraft-parent:1.3.4.   
修改组件依赖:   
pom.xml中新增dependency:com.alipay.dmeta:dmeta-common-holo-rewrite:1.0.0.20191014.   
修改组件依赖:   
pom.xml中修改dependency将org.apache.shiro:shiro-spring的版本由1.8.0修改为1.9.1.   
修改组件依赖:   
pom.xml中修改dependency将org.springframework.security:spring-security-saml2-service-provider的版本由5.2.0.RELEASE修改为5.2.4.RELEASE.   

本功能是自动修复漏洞功能，需要人工确认修复是否正确。