### PR TITLE
Automated repair through risk intelligence platform in 2023-05-30 16:29:42

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,113 +21,168 @@
     </dependencyManagement>
     <dependencies>
         <dependency>
+            <groupId>com.alipay.jcs</groupId>
+            <artifactId>jcs-common-model</artifactId>
+            <version>1.0.20171213</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alipay.kbdatafactory</groupId>
+            <artifactId>kbdatafactory-runtime-spi</artifactId>
+            <version>1.0.0.20200529</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alipay.rule</groupId>
+            <artifactId>rulelib-bom</artifactId>
+            <version>1.0.1.23</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flume</groupId>
+            <artifactId>flume-ng-sources</artifactId>
+            <version>1.11.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.taobao.vipserver</groupId>
+            <artifactId>vipserver-client</artifactId>
+            <version>4.6.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.9</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alipay.cif.service</groupId>
+            <artifactId>cif-service-facade</artifactId>
+            <version>1.8.73.20190424</version>
+        </dependency>
+        <dependency>
+            <groupId>poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>3.10.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alipay.rule</groupId>
+            <artifactId>rule-core-repository</artifactId>
+            <version>2.2.23</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alipay.dmeta</groupId>
+            <artifactId>dmeta-common-holo-rewrite</artifactId>
+            <version>1.0.0.20191014</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>jraft-parent</artifactId>
+            <version>1.3.4</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-client</artifactId>
-            <version>5.7.0</version>
+            <version>5.7.5</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-web</artifactId>
-            <version>5.6.0</version>
+            <version>5.6.9</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-config</artifactId>
-            <version>5.6.0</version>
+            <version>5.6.9</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-messaging</artifactId>
-            <version>5.0.0.RELEASE</version>
+            <version>5.0.5.RELEASE</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-commons</artifactId>
-            <version>2.0.0.RELEASE</version>
+            <version>2.0.6.RELEASE</version>
         </dependency>
 
 
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-yarn-server-resourcemanager</artifactId>
-            <version>3.3.0</version>
+            <version>3.3.4</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-config-server</artifactId>
-            <version>2.0.0.RELEASE</version>
+            <version>2.0.4.RELEASE</version>
         </dependency>
 
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>easyexcel</artifactId>
-            <version>1.0.0-RELEASE</version>
+            <version>1.0.2</version>
         </dependency>
 
         <dependency>
             <groupId>net.bull.javamelody</groupId>
             <artifactId>javamelody-spring-boot-starter</artifactId>
-            <version>1.73.0</version>
+            <version>1.74.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-app</artifactId>
-            <version>1.13</version>
+            <version>1.19</version>
         </dependency>
 
 
         <dependency>
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
-            <version>2.3.0.RELEASE</version>
+            <version>2.3.3.RELEASE</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-all</artifactId>
-            <version>1.8.0</version>
+            <version>1.9.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-core</artifactId>
-            <version>1.8.0</version>
+            <version>1.9.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-web</artifactId>
-            <version>1.8.0</version>
+            <version>1.10.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-spring</artifactId>
-            <version>1.8.0</version>
+            <version>1.9.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-saml2-service-provider</artifactId>
-            <version>5.2.0.RELEASE</version>
+            <version>5.2.4.RELEASE</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.webflow</groupId>
             <artifactId>spring-webflow</artifactId>
-            <version>2.4.0.RELEASE</version>
+            <version>2.4.5</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-batch</artifactId>
-            <version>3.0.0</version>
+            <version>4.2.3.RELEASE</version>
         </dependency>
 
        
@@ -135,7 +190,7 @@
         <dependency>
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-robotframework</artifactId>
-            <version>3.3.0</version>
+            <version>3.4.0</version>
         </dependency>
 
 
@@ -144,20 +199,20 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-all</artifactId>
-            <version>5.15.12</version>
-            <type>pom</type>
+            <version>5.15.13</version>
+            <type>jar</type>
         </dependency>
 
         <dependency>
             <groupId>org.apache.syncope</groupId>
             <artifactId>syncope-archetype</artifactId>
-            <version>2.1.0</version>
+            <version>2.1.7</version>
         </dependency>
 
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.3.2</version>
+            <version>1.3.3</version>
         </dependency>
 
      
@@ -165,32 +220,32 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.59</version>
+            <version>1.60</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-shared-utils</artifactId>
-            <version>3.2.1</version>
-            <type>pom</type>
+            <version>3.3.3</version>
+            <type>jar</type>
         </dependency>
 
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
-            <version>1.9</version>
+            <version>1.19.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>3.0.6</version>
+            <version>3.0.16</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.geode</groupId>
             <artifactId>geode-core</artifactId>
-            <version>1.14.4</version>
+            <version>1.15.0</version>
         </dependency>
 
       
@@ -219,7 +274,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.68</version>
+            <version>2.8.3</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
修改组件依赖:   
pom.xml中修改dependency将org.apache.maven.shared:maven-shared-utils的版本由3.2.1修改为3.3.3.   
修改组件依赖:   
pom.xml中修改dependency将org.springframework.security.oauth:spring-security-oauth2的版本由2.3.0.RELEASE修改为2.3.3.RELEASE.   
修改组件依赖:   
pom.xml中修改dependency将org.springframework.webflow:spring-webflow的版本由2.4.0.RELEASE修改为2.4.5.   
修改组件依赖:   
pom.xml中修改dependency将org.apache.syncope:syncope-archetype的版本由2.1.0修改为2.1.7.   
修改组件依赖:   
pom.xml中修改dependency将org.apache.geode:geode-core的版本由1.14.4修改为1.15.0.   
修改组件依赖:   
pom.xml中修改dependency将org.codehaus.plexus:plexus-utils的版本由3.0.6修改为3.0.16.   
修改组件依赖:   
pom.xml中新增dependency:com.alipay.sofa:jraft-parent:1.3.4.   
修改组件依赖:   
pom.xml中新增dependency:com.alipay.dmeta:dmeta-common-holo-rewrite:1.0.0.20191014.   
修改组件依赖:   
pom.xml中修改dependency将org.apache.shiro:shiro-spring的版本由1.8.0修改为1.9.1.   
修改组件依赖:   
pom.xml中修改dependency将org.springframework.security:spring-security-saml2-service-provider的版本由5.2.0.RELEASE修改为5.2.4.RELEASE.   
修改组件依赖:   
pom.xml中修改dependency将org.springframework.security:spring-security-config的版本由5.6.0修改为5.6.9.   
修改组件依赖:   
pom.xml中修改dependency将org.apache.shiro:shiro-web的版本由1.8.0修改为1.10.0.   
修改组件依赖:   
pom.xml中修改dependency将org.springframework.data:spring-data-commons的版本由2.0.0.RELEASE修改为2.0.6.RELEASE.   
修改组件依赖:   
pom.xml中修改dependency将org.springframework:spring-messaging的版本由5.0.0.RELEASE修改为5.0.5.RELEASE.   
修改组件依赖:   
pom.xml中新增dependency:com.alipay.rule:rule-core-repository:2.2.23.   
修改组件依赖:   
pom.xml中修改dependency将org.apache.camel:camel-robotframework的版本由3.3.0修改为3.4.0.   
修改组件依赖:   
pom.xml中新增dependency:poi:poi-ooxml:3.10.1.   
修改组件依赖:   
pom.xml中修改dependency将org.apache.shiro:shiro-core的版本由1.8.0修改为1.9.1.   
修改组件依赖:   
pom.xml中修改dependency将org.apache.shiro:shiro-all的版本由1.8.0修改为1.9.1.   
修改组件依赖:   
pom.xml中新增dependency:com.alipay.cif.service:cif-service-facade:1.8.73.20190424.   
修改组件依赖:   
pom.xml中修改dependency将org.springframework.security:spring-security-web的版本由5.6.0修改为5.6.9.   
修改组件依赖:   
pom.xml中修改dependency将org.bouncycastle:bcprov-jdk15on的版本由1.59修改为1.60.   
修改组件依赖:   
pom.xml中修改dependency将org.apache.tika:tika-app的版本由1.13修改为1.19.   
修改组件依赖:   
pom.xml中修改dependency将com.alibaba:fastjson的版本由1.2.68修改为2.8.3.   
修改组件依赖:   
pom.xml中新增dependency:com.google.code.gson:gson:2.8.9.   
修改组件依赖:   
pom.xml中新增dependency:com.taobao.vipserver:vipserver-client:4.6.3.   
修改组件依赖:   
pom.xml中新增dependency:org.apache.flume:flume-ng-sources:1.11.0.   
修改组件依赖:   
pom.xml中新增dependency:com.alipay.rule:rulelib-bom:1.0.1.23.   
修改组件依赖:   
pom.xml中修改dependency将org.springframework.security:spring-security-oauth2-client的版本由5.7.0修改为5.7.5.   
修改组件依赖:   
pom.xml中修改dependency将org.apache.tika:tika-core的版本由1.9修改为1.19.1.   
修改组件依赖:   
pom.xml中修改dependency将net.bull.javamelody:javamelody-spring-boot-starter的版本由1.73.0修改为1.74.0.   
修改组件依赖:   
pom.xml中新增dependency:com.alipay.kbdatafactory:kbdatafactory-runtime-spi:1.0.0.20200529.   
修改组件依赖:   
pom.xml中新增dependency:com.alipay.jcs:jcs-common-model:1.0.20171213.   
修改组件依赖:   
pom.xml中修改dependency将org.apache.activemq:activemq-all的版本由5.15.12修改为5.15.13.   
修改组件依赖:   
pom.xml中修改dependency将org.apache.hadoop:hadoop-yarn-server-resourcemanager的版本由3.3.0修改为3.3.4.   
修改组件依赖:   
pom.xml中修改dependency将commons-fileupload:commons-fileupload的版本由1.3.2修改为1.3.3.   
修改组件依赖:   
pom.xml中修改dependency将com.alibaba:easyexcel的版本由1.0.0-RELEASE修改为1.0.2.   
修改组件依赖:   
pom.xml中修改dependency将org.springframework.cloud:spring-cloud-config-server的版本由2.0.0.RELEASE修改为2.0.4.RELEASE.   
修改组件依赖:   
pom.xml中修改dependency将org.springframework.boot:spring-boot-starter-batch的版本由3.0.0修改为4.2.3.RELEASE.   

本功能是自动修复漏洞功能，需要人工确认修复是否正确。