### PR TITLE
Automated repair through risk intelligence platform in 2023-06-01 13:38:48

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,8 +171,8 @@
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-shared-utils</artifactId>
-            <version>3.2.1</version>
-            <type>pom</type>
+            <version>3.3.3</version>
+            <type>jar</type>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
修改组件依赖:   
pom.xml中修改dependency将org.apache.maven.shared:maven-shared-utils的版本由3.2.1修改为3.3.3.   

本功能是自动修复漏洞功能，需要人工确认修复是否正确。