### PR TITLE
Automated repair through risk intelligence platform in 2023-06-13 14:07:23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
-            <version>2.3.0.RELEASE</version>
+            <version>2.3.3.RELEASE</version>
         </dependency>
 
         <dependency>
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>org.springframework.webflow</groupId>
             <artifactId>spring-webflow</artifactId>
-            <version>2.4.0.RELEASE</version>
+            <version>2.4.5</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
修改组件依赖:   
pom.xml中修改dependency将org.springframework.security.oauth:spring-security-oauth2的版本由2.3.0.RELEASE修改为2.3.3.RELEASE.   
修改组件依赖:   
pom.xml中修改dependency将org.springframework.webflow:spring-webflow的版本由2.4.0.RELEASE修改为2.4.5.   

本功能是自动修复漏洞功能，需要人工确认修复是否正确。